### PR TITLE
Add CLI for generating and persisting embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,152 @@
 # Impact Explorer
 
-This project implements a FastAPI server that integrates with Anthropic's Claude API to provide a chat interface. It includes both a backend server and a simple frontend for interacting with Claude.
-Additionally, it features a powerful CLI tool for document processing and embedding generation.
+This project implements a FastAPI server that integrates with Anthropic's Claude API to provide a chat interface enhanced with Retrieval-Augmented Generation (RAG) capabilities. It includes both a backend server and a simple frontend for interacting with Claude. Additionally, it features a powerful CLI tool for document processing and embedding generation using ChromaDB.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Configuration](#configuration)
+- [Running the Server](#running-the-server)
+- [Document Processing CLI](#document-processing-cli)
+  - [Features](#features)
+  - [Usage](#usage)
+  - [Output](#output)
+- [Important Notes](#important-notes)
+- [Development](#development)
+- [License](#license)
 
 ## Prerequisites
 
 - Python 3.7+
 - An Anthropic API key
+- ChromaDB installed and configured
+- SentenceTransformers for embedding generation
 
 ## Setup
 
-1. Clone this repository:
-   ```
+1. **Clone this repository:**
+
+   ```bash
    git clone https://github.com/moradology/impact-explorer.git
    cd impact-explorer
    ```
 
-2. Setup Python virtual environment
-The following will set up a virtual environment and the development dependencies:
+2. **Setup Python virtual environment**
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-make install-dev
-```
+   The following will set up a virtual environment and the development dependencies:
 
-3. Install dependencies from `pyproject.toml`:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   make install-dev
    ```
+
+3. **Install dependencies from `pyproject.toml`:**
+
+   ```bash
    make install
    ```
 
    If you're developing the project, install with editable mode:
-   ```
+
+   ```bash
    make install-dev
    ```
 
+## Configuration
+
+Before running the server or using the CLI, you need to set several environment variables.
+
+1. **Anthropic API Key**
+
+   Set your Anthropic API key as an environment variable:
+
+   - On Unix or macOS:
+
+     ```bash
+     export ANTHROPIC_API_KEY=your_api_key_here
+     ```
+
+   - On Windows (Command Prompt):
+
+     ```bash
+     set ANTHROPIC_API_KEY=your_api_key_here
+     ```
+
+   - On Windows (PowerShell):
+
+     ```powershell
+     $env:ANTHROPIC_API_KEY = "your_api_key_here"
+     ```
+
+2. **ChromaDB Path**
+
+   Set the path where your ChromaDB database is stored:
+
+   - On Unix or macOS:
+
+     ```bash
+     export CHROMA_PATH=/path/to/your/chromadb/
+     ```
+
+   - On Windows (Command Prompt):
+
+     ```bash
+     set CHROMA_PATH=C:\path\to\your\chromadb
+     ```
+
+   - On Windows (PowerShell):
+
+     ```powershell
+     $env:CHROMA_PATH = "C:\path\to\your\chromadb"
+     ```
+
+3. **Embedding Model Name**
+
+   Set the name of the embedding model you are using:
+
+   - On Unix or macOS:
+
+     ```bash
+     export EMBEDDING_MODEL=all-distilroberta-v1
+     ```
+
+   - On Windows (Command Prompt):
+
+     ```bash
+     set EMBEDDING_MODEL=all-distilroberta-v1
+     ```
+
+   - On Windows (PowerShell):
+
+     ```powershell
+     $env:EMBEDDING_MODEL = "all-distilroberta-v1"
+     ```
+
+   **Note:** The embedding model specified here must match the one used during the document embedding process for ChromaDB.
+
+## Running the Server
+
+1. **Start the FastAPI server:**
+
+   ```bash
+   make run
+   ```
+
+   The server will start running on `http://localhost:8000`.
+
+2. **Navigate to the Frontend:**
+
+   Open your browser and go to `http://localhost:8000`. The `templates/index.html` will be hosted at the application root (`/`).
+
+3. **Chat Interface:**
+
+   Use the chat interface to interact with Claude. The server uses Retrieval-Augmented Generation (RAG) to enhance responses with relevant information from your documents.
+
 ## Document Processing CLI
 
-The project includes a Command Line Interface (CLI) tool for processing documents, generating embeddings, and storing them in a ChromaDB database. This is useful for preparing data for Retrieval-Augmented Generation (RAG) tasks.
+The project includes a Command Line Interface (CLI) tool for processing documents, generating embeddings, and storing them in a ChromaDB database. This is essential for preparing data for Retrieval-Augmented Generation (RAG) tasks.
 
 ### Features
 
@@ -51,67 +160,64 @@ The project includes a Command Line Interface (CLI) tool for processing document
 To use the document processing CLI:
 
 ```bash
-python src/impact_explorer/cli/document_processor.py --input <input_file> --output <output_dir> --chunking-strategy <strategy> [strategy-specific-args] --embedding-model <model_name>
+python src/impact_explorer/cli/document_processor.py --input <input_file_or_directory> --output <output_dir> --chunking-strategy <strategy> [strategy-specific-args] --embedding-model <model_name>
 ```
 
-Example command:
+**Example command:**
 
 ```bash
-python src/impact_explorer/cli/document_processor.py --input documents/mobydick.txt --output ./moby_db/ --chunking-strategy sliding-window --chunk_size 100 --overlap 20 --embedding-model distilbert-base-uncased
+python src/impact_explorer/cli/document_processor.py \
+  --input documents/mobydick.txt \
+  --output ./moby_db/ \
+  --chunking-strategy sliding-window \
+  --chunk_size 100 \
+  --overlap 20 \
+  --embedding-model all-distilroberta-v1
 ```
 
 This command will:
-- Process documents/mobydick.txt
+
+- Process `documents/mobydick.txt`
 - Use a sliding window strategy with a window size of 100 and overlap of 20
-- Generate embeddings using the distilled bert model
-- Store the results in ChromaDB in the ./moby_db/ directory
+- Generate embeddings using the `all-distilroberta-v1` model
+- Store the results in ChromaDB in the `./moby_db/` directory
+
+**Important:** Ensure that the `--embedding-model` parameter matches the `EMBEDDING_MODEL` environment variable used by the server.
 
 ### Output
 
 After processing, the CLI will display statistics about the generated ChromaDB collection, including:
+
 - Total number of documents
 - Embedding dimensions
 - Metadata fields
-- A look at sample documents
+- Sample documents
 - Document length statistics
 
-The processed data can be loaded for RAG queries on FastAPI startup.
+The processed data is stored in ChromaDB and can be loaded for RAG queries on FastAPI startup.
 
-## Configuration
+## Important Notes
 
-Set your Anthropic API key as an environment variable:
+- **Embedding Model Consistency:** The embedding model used in both the CLI and the server must be the same. This ensures that the embeddings generated for the user's queries are compatible with those stored in ChromaDB.
 
-- On Unix or MacOS:
-  ```
-  export ANTHROPIC_API_KEY=your_api_key_here
-  ```
+  - **Example:**
 
-- On Windows (Command Prompt):
-  ```
-  set ANTHROPIC_API_KEY=your_api_key_here
-  ```
+    If you used `all-distilroberta-v1` for generating embeddings in the CLI, set:
 
-- On Windows (PowerShell):
-  ```
-  $env:ANTHROPIC_API_KEY = "your_api_key_here"
-  ```
+    ```bash
+    export EMBEDDING_MODEL=all-distilroberta-v1
+    ```
 
-## Running the Server
+- **Retrieval-Augmented Generation (RAG):**
 
-1. Start the FastAPI server:
-   ```bash
-   make run
-   ```
+  The server uses the user's query to retrieve the most relevant documents from ChromaDB and includes them in the prompt sent to the LLM. This enhances the response with specific information from your document collection.
 
-   The server will start running on `http://localhost:8000`.
-
-   Navigate to the server in a browser and `templates/index.html` will be hosted on application root (`/`).
 
 ## Development
 
 To run the server in development mode with auto-reload:
 
-```python
+```bash
 make run
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Impact Explorer
 
 This project implements a FastAPI server that integrates with Anthropic's Claude API to provide a chat interface. It includes both a backend server and a simple frontend for interacting with Claude.
+Additionally, it features a powerful CLI tool for document processing and embedding generation.
 
 ## Prerequisites
 
@@ -33,6 +34,48 @@ make install-dev
    ```
    make install-dev
    ```
+
+## Document Processing CLI
+
+The project includes a Command Line Interface (CLI) tool for processing documents, generating embeddings, and storing them in a ChromaDB database. This is useful for preparing data for Retrieval-Augmented Generation (RAG) tasks.
+
+### Features
+
+- Support for various chunking strategies (e.g., sliding window)
+- Flexible embedding model selection
+- Integration with ChromaDB for efficient storage and retrieval
+- Detailed output statistics for processed documents
+
+### Usage
+
+To use the document processing CLI:
+
+```bash
+python src/impact_explorer/cli/document_processor.py --input <input_file> --output <output_dir> --chunking-strategy <strategy> [strategy-specific-args] --embedding-model <model_name>
+```
+
+Example command:
+
+```bash
+python src/impact_explorer/cli/document_processor.py --input documents/mobydick.txt --output ./moby_db/ --chunking-strategy sliding-window --chunk_size 100 --overlap 20 --embedding-model distilbert-base-uncased
+```
+
+This command will:
+- Process documents/mobydick.txt
+- Use a sliding window strategy with a window size of 100 and overlap of 20
+- Generate embeddings using the distilled bert model
+- Store the results in ChromaDB in the ./moby_db/ directory
+
+### Output
+
+After processing, the CLI will display statistics about the generated ChromaDB collection, including:
+- Total number of documents
+- Embedding dimensions
+- Metadata fields
+- A look at sample documents
+- Document length statistics
+
+The processed data can be loaded for RAG queries on FastAPI startup.
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ dependencies = [
     "anthropic",
     "jinja2",
     "python-multipart",
-    "ruff",
-    "mypy",
+    "sentence-transformers"
 ]
 
 [project.optional-dependencies]
@@ -30,6 +29,8 @@ dev = [
     "isort",
     "pytest",
     "httpx",
+    "ruff",
+    "mypy",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "sentence-transformers",
     "chromadb",
     "spacy",
+    "PyPDF2",
+    "python-docx",
+    "markdown2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "anthropic",
     "jinja2",
     "python-multipart",
-    "sentence-transformers"
+    "sentence-transformers",
+    "chromadb",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-multipart",
     "sentence-transformers",
     "chromadb",
+    "spacy",
 ]
 
 [project.optional-dependencies]

--- a/src/impact_explorer/cli/chunking_strategies.py
+++ b/src/impact_explorer/cli/chunking_strategies.py
@@ -1,0 +1,138 @@
+from abc import ABC, abstractmethod
+import argparse
+from typing import List, Optional, Dict, Any
+from dataclasses import dataclass
+
+@dataclass
+class Chunk:
+    text: str
+    start_index: int
+    end_index: int
+    metadata: Optional[dict] = None
+
+
+class ChunkingStrategy(ABC):
+    """
+    Abstract Base Class for text chunking strategies.
+    """
+
+    @abstractmethod
+    def chunk(self, text: str, **kwargs) -> List[Chunk]:
+        """
+        Chunk the input text into smaller pieces with metadata.
+
+        Args:
+            text (str): The input text to be chunked.
+            **kwargs: Strategy-specific arguments.
+
+        Returns:
+            List[Chunk]: A list of Chunk objects containing text and metadata.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        """
+        Get the list of required arguments for this strategy.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def from_args(cls, args: argparse.Namespace) -> 'ChunkingStrategy':
+        """
+        Build an instance of this class with supplied arguments
+        """
+        pass
+
+class SlidingWindowStrategy(ChunkingStrategy):
+
+    def __init__(self, chunk_size: int, overlap: int):
+        self.chunk_size = chunk_size
+        self.overlap = overlap
+
+    def chunk(self, text: str) -> List[Chunk]:
+        chunks = []
+        start = 0
+        while start < len(text):
+            end = start + self.chunk_size
+            chunk_text = text[start:end]
+            chunks.append(Chunk(
+                text=chunk_text,
+                start_index=start,
+                end_index=end,
+                metadata={
+                    "length": len(chunk_text),
+                    "tokens": chunk_text.split()  # Simple tokenization
+                }
+            ))
+            start += self.chunk_size - self.overlap
+        return chunks
+
+    def __str__(self) -> str:
+        """Return a string representation suitable for filenames."""
+        return f"sliding-window_size-{self.chunk_size}_overlap-{self.overlap}"
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--chunk_size", type=int, required=True, help="Size of each chunk for sliding window")
+        parser.add_argument("--overlap", type=int, required=True, help="Size of sliding window overlap chunks")
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> 'ChunkingStrategy':
+        """
+        Build an instance of this class with supplied arguments
+        """
+        return cls(chunk_size=args.chunk_size, overlap=args.overlap)
+
+
+class SentenceStrategy(ChunkingStrategy):
+
+    def __init__(self, max_sentences: int):
+        self.max_sentences = max_sentences
+
+    def chunk(self, text: str, **kwargs) -> List[Chunk]:
+        max_sentences = kwargs.get('max_sentences', 5)
+        import nltk
+        nltk.download('punkt', quiet=True)
+        sentences = nltk.sent_tokenize(text)
+        
+        chunks = []
+        for i in range(0, len(sentences), max_sentences):
+            chunk_sentences = sentences[i:i+max_sentences]
+            chunk_text = ' '.join(chunk_sentences)
+            start_index = text.index(chunk_sentences[0])
+            end_index = start_index + len(chunk_text)
+            chunks.append(Chunk(
+                text=chunk_text,
+                start_index=start_index,
+                end_index=end_index,
+                metadata={
+                    "num_sentences": len(chunk_sentences),
+                    "tokens": chunk_text.split()
+                }
+            ))
+        return chunks
+
+
+    def __str__(self) -> str:
+        """Return a string representation suitable for filenames."""
+        return f"sentence_max-{self.max_sentences}"
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--max_sentences", type=int, required=True, help="Maximum number of sentences per chunk")
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> 'ChunkingStrategy':
+        """
+        Build an instance of this class with supplied arguments
+        """
+        return cls(max_sentences=args.max_sentences)
+
+
+strategies = {
+    "sentence": SentenceStrategy,
+    "sliding-window": SlidingWindowStrategy
+}

--- a/src/impact_explorer/cli/chunking_strategies.py
+++ b/src/impact_explorer/cli/chunking_strategies.py
@@ -49,10 +49,9 @@ class SlidingWindowStrategy(ChunkingStrategy):
     """
     Implements sliding window chunking with overlapping text segments.
     """
-    def __init__(self, chunk_size: int, overlap: int, embedding_model: str):
+    def __init__(self, chunk_size: int, overlap: int):
         self.chunk_size = chunk_size
         self.overlap = overlap
-        self.tokenizer = AutoTokenizer.from_pretrained(embedding_model)
 
     def chunk(self, text: str) -> List[Chunk]:
         """
@@ -68,10 +67,7 @@ class SlidingWindowStrategy(ChunkingStrategy):
                     text=chunk_text,
                     start_index=start,
                     end_index=end,
-                    metadata={
-                        "length": len(chunk_text),
-                        "tokens": self.tokenizer.tokenize(chunk_text),
-                    },
+                    metadata={"window_length": len(chunk_text)},
                 )
             )
             start += self.chunk_size - self.overlap
@@ -107,18 +103,16 @@ class SlidingWindowStrategy(ChunkingStrategy):
         Build an instance with supplied arguments.
         """
         return cls(chunk_size=args.chunk_size,
-                   overlap=args.overlap,
-                   embedding_model=args.embedding_model)
+                   overlap=args.overlap)
 
 
 class SentenceStrategy(ChunkingStrategy):
     """
     Implements sentence-based chunking strategy.
     """
-    def __init__(self, max_sentences: int, overlap: int, embedding_model: str):
+    def __init__(self, max_sentences: int, overlap: int):
         self.max_sentences = max_sentences
         self.overlap = overlap
-        self.tokenizer = AutoTokenizer.from_pretrained(embedding_model)
         self.nlp = load_spacy_model()
 
 
@@ -147,10 +141,7 @@ class SentenceStrategy(ChunkingStrategy):
                     text=chunk_text,
                     start_index=start_index,
                     end_index=end_index,
-                    metadata={
-                        "num_sentences": len(chunk_sentences),
-                        "tokens": self.tokenizer.tokenize(chunk_text)
-                    },
+                    metadata={"num_sentences": len(chunk_sentences)},
                 )
             )
 
@@ -189,8 +180,7 @@ class SentenceStrategy(ChunkingStrategy):
         Build an instance with supplied arguments.
         """
         return cls(max_sentences=args.max_sentences,
-                   overlap=args.overlap,
-                   embedding_model=args.embedding_model)
+                   overlap=args.overlap)
 
 class TokenTextSplitterStrategy:
     """

--- a/src/impact_explorer/cli/chunking_strategies.py
+++ b/src/impact_explorer/cli/chunking_strategies.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional
 from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
-
+from utils import load_spacy_model
 
 @dataclass
 class Chunk:
@@ -89,7 +89,7 @@ class SlidingWindowStrategy(ChunkingStrategy):
         Add arguments for sliding window strategy.
         """
         parser.add_argument(
-            "--chunk_size",
+            "--chunk-size",
             type=int,
             required=True,
             help="Size of each chunk for sliding window",
@@ -115,31 +115,32 @@ class SentenceStrategy(ChunkingStrategy):
     """
     Implements sentence-based chunking strategy.
     """
-    def __init__(self, max_sentences: int, embedding_model: str):
+    def __init__(self, max_sentences: int, overlap: int, embedding_model: str):
         self.max_sentences = max_sentences
+        self.overlap = overlap
         self.tokenizer = AutoTokenizer.from_pretrained(embedding_model)
-        self.model = AutoModelForTokenClassification.from_pretrained(embedding_model)
-        self.nlp = pipeline('token-classification', model=self.model, tokenizer=self.tokenizer)
+        self.nlp = load_spacy_model()
 
-    def chunk(self, text: str, **kwargs) -> List[Chunk]:
+
+    def chunk(self, text: str) -> List[Chunk]:
         """
         Chunk text by grouping sentences.
         """
-        max_sentences = kwargs.get("max_sentences", self.max_sentences)
-        sentences = self.nlp(text, aggregation_strategy="simple")
-        sentences = [sentence['word'] for sentence in sentences]
+        max_sentences = self.max_sentences
+        doc = self.nlp(text)
+        sentences = [sent.text for sent in doc.sents]
 
         chunks = []
         current_position = 0
 
-        for i in range(0, len(sentences), max_sentences):
+        i = 0
+        while i < len(sentences):
             chunk_sentences = sentences[i: i + max_sentences]
+            # Combine sentences into chunk text
             chunk_text = " ".join(chunk_sentences)
             start_index = current_position
             end_index = start_index + len(chunk_text)
             current_position = end_index + 1
-
-            tokens = self.tokenizer.tokenize(chunk_text)
 
             chunks.append(
                 Chunk(
@@ -148,17 +149,21 @@ class SentenceStrategy(ChunkingStrategy):
                     end_index=end_index,
                     metadata={
                         "num_sentences": len(chunk_sentences),
-                        "tokens": tokens,
+                        "tokens": self.tokenizer.tokenize(chunk_text)
                     },
                 )
             )
+
+            # next chunk with overlap
+            i += max_sentences - self.overlap
+
         return chunks
 
     def __str__(self) -> str:
         """
         Return a string representation suitable for filenames.
         """
-        return f"sentence_max-{self.max_sentences}"
+        return f"sentence_max{self.max_sentences}_overlap{self.overlap}"
 
     @classmethod
     def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
@@ -166,10 +171,16 @@ class SentenceStrategy(ChunkingStrategy):
         Add arguments for sentence-based chunking strategy.
         """
         parser.add_argument(
-            "--max_sentences",
+            "--max-sentences",
             type=int,
             required=True,
             help="Maximum number of sentences per chunk",
+        )
+        parser.add_argument(
+            "--overlap",
+            type=int,
+            required=True,
+            help="Sentence overlap",
         )
 
     @classmethod
@@ -178,7 +189,94 @@ class SentenceStrategy(ChunkingStrategy):
         Build an instance with supplied arguments.
         """
         return cls(max_sentences=args.max_sentences,
+                   overlap=args.overlap,
                    embedding_model=args.embedding_model)
 
+class TokenTextSplitterStrategy:
+    """
+    Implements chunking by splitting text into chunks based on tokenization.
 
-strategies = {"sentence": SentenceStrategy, "sliding-window": SlidingWindowStrategy}
+    Currently just busted as hell. TODO: fix it
+    """
+    def __init__(self, max_tokens: int, overlap: int, embedding_model: str):
+        """
+        Initializes TokenTextSplitter with max token count and overlap.
+
+        :param max_tokens: Maximum number of tokens per chunk.
+        :param overlap: Number of overlapping tokens between chunks.
+        :param embedding_model: Pre-trained model to use for tokenization.
+        """
+        self.max_tokens = max_tokens
+        self.overlap = overlap
+        self.tokenizer = AutoTokenizer.from_pretrained(embedding_model)
+
+    def chunk(self, text: str) -> List[Chunk]:
+        """
+        Chunk text using token-based strategy with overlap.
+
+        :param text: The input text to be chunked.
+        :return: A list of Chunk objects.
+        """
+        tokens = self.tokenizer.encode(text, add_special_tokens=False)
+        chunks = []
+
+        start = 0
+        while start < len(tokens):
+            end = min(start + self.max_tokens, len(tokens))
+            token_chunk = tokens[start:end]
+            chunk_text = self.tokenizer.decode(token_chunk, skip_special_tokens=True, clean_up_tokenization_spaces=True)
+
+            chunks.append(
+                Chunk(
+                    text=chunk_text,
+                    start_index=start,
+                    end_index=end,
+                    metadata={
+                        "length": len(chunk_text),
+                        "tokens": token_chunk
+                    },
+                )
+            )
+            # Move start forward by max_tokens minus overlap to create overlap
+            start += self.max_tokens - self.overlap
+
+        return chunks
+
+    def __str__(self) -> str:
+        """
+        Return a string representation suitable for filenames.
+        """
+        return f"tokentext_max{self.max_tokens}_overlap{self.overlap}"
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        """
+        Add arguments for sentence-based chunking strategy.
+        """
+        parser.add_argument(
+            "--max-tokens",
+            type=int,
+            required=True,
+            help="Maximum number of tokens per chunk",
+        )
+        parser.add_argument(
+            "--overlap",
+            type=int,
+            required=True,
+            help="Token overlap",
+        )
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> "ChunkingStrategy":
+        """
+        Build an instance with supplied arguments.
+        """
+        return cls(max_tokens=args.max_tokens,
+                   overlap=args.overlap,
+                   embedding_model=args.embedding_model)
+
+strategies = {
+    "sentence": SentenceStrategy,
+    "sliding-window": SlidingWindowStrategy,
+    "token-text": TokenTextSplitterStrategy,
+}

--- a/src/impact_explorer/cli/chunking_strategies.py
+++ b/src/impact_explorer/cli/chunking_strategies.py
@@ -2,14 +2,17 @@ import argparse
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional
-from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
+
+from transformers import AutoTokenizer
 from utils import load_spacy_model
+
 
 @dataclass
 class Chunk:
     """
     Represents a chunk of text with start/end indices and metadata.
     """
+
     text: str
     start_index: int
     end_index: int
@@ -49,6 +52,7 @@ class SlidingWindowStrategy(ChunkingStrategy):
     """
     Implements sliding window chunking with overlapping text segments.
     """
+
     def __init__(self, chunk_size: int, overlap: int):
         self.chunk_size = chunk_size
         self.overlap = overlap
@@ -102,19 +106,18 @@ class SlidingWindowStrategy(ChunkingStrategy):
         """
         Build an instance with supplied arguments.
         """
-        return cls(chunk_size=args.chunk_size,
-                   overlap=args.overlap)
+        return cls(chunk_size=args.chunk_size, overlap=args.overlap)
 
 
 class SentenceStrategy(ChunkingStrategy):
     """
     Implements sentence-based chunking strategy.
     """
+
     def __init__(self, max_sentences: int, overlap: int):
         self.max_sentences = max_sentences
         self.overlap = overlap
         self.nlp = load_spacy_model()
-
 
     def chunk(self, text: str) -> List[Chunk]:
         """
@@ -129,7 +132,7 @@ class SentenceStrategy(ChunkingStrategy):
 
         i = 0
         while i < len(sentences):
-            chunk_sentences = sentences[i: i + max_sentences]
+            chunk_sentences = sentences[i : i + max_sentences]
             # Combine sentences into chunk text
             chunk_text = " ".join(chunk_sentences)
             start_index = current_position
@@ -179,8 +182,8 @@ class SentenceStrategy(ChunkingStrategy):
         """
         Build an instance with supplied arguments.
         """
-        return cls(max_sentences=args.max_sentences,
-                   overlap=args.overlap)
+        return cls(max_sentences=args.max_sentences, overlap=args.overlap)
+
 
 class TokenTextSplitterStrategy:
     """
@@ -188,6 +191,7 @@ class TokenTextSplitterStrategy:
 
     Currently just busted as hell. TODO: fix it
     """
+
     def __init__(self, max_tokens: int, overlap: int, embedding_model: str):
         """
         Initializes TokenTextSplitter with max token count and overlap.
@@ -214,17 +218,16 @@ class TokenTextSplitterStrategy:
         while start < len(tokens):
             end = min(start + self.max_tokens, len(tokens))
             token_chunk = tokens[start:end]
-            chunk_text = self.tokenizer.decode(token_chunk, skip_special_tokens=True, clean_up_tokenization_spaces=True)
+            chunk_text = self.tokenizer.decode(
+                token_chunk, skip_special_tokens=True, clean_up_tokenization_spaces=True
+            )
 
             chunks.append(
                 Chunk(
                     text=chunk_text,
                     start_index=start,
                     end_index=end,
-                    metadata={
-                        "length": len(chunk_text),
-                        "tokens": token_chunk
-                    },
+                    metadata={"length": len(chunk_text), "tokens": token_chunk},
                 )
             )
             # Move start forward by max_tokens minus overlap to create overlap
@@ -261,9 +264,12 @@ class TokenTextSplitterStrategy:
         """
         Build an instance with supplied arguments.
         """
-        return cls(max_tokens=args.max_tokens,
-                   overlap=args.overlap,
-                   embedding_model=args.embedding_model)
+        return cls(
+            max_tokens=args.max_tokens,
+            overlap=args.overlap,
+            embedding_model=args.embedding_model,
+        )
+
 
 strategies = {
     "sentence": SentenceStrategy,

--- a/src/impact_explorer/cli/document_processor.py
+++ b/src/impact_explorer/cli/document_processor.py
@@ -5,12 +5,11 @@ import sys
 from typing import List
 
 import chromadb
-from sentence_transformers import SentenceTransformer
-import PyPDF2
 import docx
 import markdown2
-
+import PyPDF2
 from chunking_strategies import Chunk, ChunkingStrategy, strategies
+from sentence_transformers import SentenceTransformer
 from utils import generate_doc_id, print_chroma_stats, print_model_help
 
 
@@ -92,7 +91,7 @@ def parse_arguments() -> argparse.Namespace:
         chunking_strategy=chunking_strategy,
         embedding_model=args.embedding_model,
         input_file=input_file,
-        input_dir=input_dir
+        input_dir=input_dir,
     )
 
     return final_args
@@ -200,11 +199,12 @@ def add_to_chroma(
 
 
 def process_document(
-        input_file: str,
-        chunking_strategy: str,
-        embedding_model: str,
-        chroma_db_name: str,
-        output_dir: str) -> None:
+    input_file: str,
+    chunking_strategy: str,
+    embedding_model: str,
+    chroma_db_name: str,
+    output_dir: str,
+) -> None:
     text = load_document(input_file)
     chunking_strategy = chunking_strategy
     chunks = chunking_strategy.chunk(text)
@@ -241,11 +241,7 @@ def main():
     for file in files:
         print(f"Processing file: {file}")
         process_document(
-            file,
-            chunking_strategy,
-            embedding_model,
-            chroma_db_name,
-            output_dir
+            file, chunking_strategy, embedding_model, chroma_db_name, output_dir
         )
 
 

--- a/src/impact_explorer/cli/document_processor.py
+++ b/src/impact_explorer/cli/document_processor.py
@@ -5,9 +5,8 @@ import sys
 from typing import List
 
 import chromadb
-from sentence_transformers import SentenceTransformer
-
 from chunking_strategies import Chunk, ChunkingStrategy, strategies
+from sentence_transformers import SentenceTransformer
 from utils import print_chroma_stats, print_model_help
 
 
@@ -28,9 +27,9 @@ def generate_chroma_db_name(
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Document Processor and Embedder")
     parser.add_argument(
-        '--model-help',
-        action='store_true',
-        help='Display a summary of pretrained models and their trade-offs'
+        "--model-help",
+        action="store_true",
+        help="Display a summary of pretrained models and their trade-offs",
     )
     temp_args, _ = parser.parse_known_args()
 
@@ -119,18 +118,20 @@ def add_to_chroma(
     collection_name: str,
     chunks: List[Chunk],
     embeddings: List[List[float]],
-    batch_size: int = 200
+    batch_size: int = 200,
 ) -> None:
     collection = client.get_or_create_collection(collection_name)
 
     valid_chunks_embeddings = [
-        (chunk, embedding) for chunk, embedding in zip(chunks, embeddings) if len(embedding) > 0
+        (chunk, embedding)
+        for chunk, embedding in zip(chunks, embeddings)
+        if len(embedding) > 0
     ]
     if not valid_chunks_embeddings:
         raise ValueError("No valid chunks or embeddings to add to database.")
 
     for i in range(0, len(valid_chunks_embeddings), batch_size):
-        batch = valid_chunks_embeddings[i:i + batch_size]
+        batch = valid_chunks_embeddings[i : i + batch_size]
         chunk_batch = [chunk.text for chunk, _ in batch]
         embedding_batch = [embedding for _, embedding in batch]
         metadata_batch = [

--- a/src/impact_explorer/cli/document_processor.py
+++ b/src/impact_explorer/cli/document_processor.py
@@ -1,0 +1,118 @@
+import argparse
+import os
+from typing import List, Tuple
+from chunking_strategies import ChunkingStrategy, strategies, Chunk
+from utils import print_chroma_stats
+import chromadb
+import re
+from sentence_transformers import SentenceTransformer
+
+def sanitize_filename(name: str) -> str:
+    """Sanitize the input string to be used as a filename."""
+    return re.sub(r'[^\w\-_\.]', '_', name)
+
+def generate_chroma_db_name(chunking_strategy: ChunkingStrategy, embedding_model: str) -> str:
+    """Generate a unique ChromaDB name based on configuration."""
+    embedding_model_short = embedding_model.split('/')[-1]
+    db_name = f"{chunking_strategy}_{embedding_model_short}"
+    return sanitize_filename(db_name)
+
+def parse_arguments() -> argparse.Namespace:
+    print("Debug: Starting parse_arguments()")
+
+    parser = argparse.ArgumentParser(description="Document Processor and Embedder")
+    parser.add_argument("--input", required=True, help="Input file path or string")
+    parser.add_argument("--output-dir", default="./", help="Output directory for ChromaDB")
+    parser.add_argument("--chunking-strategy", required=True, choices=list(strategies.keys()), help="Chunking strategy to use")
+    parser.add_argument("--embedding-model", default="all-MiniLM-L6-v2", help="Name of the sentence-transformers model to use for embeddings")
+    
+    print("Debug: Parsing known arguments")
+    args, remaining = parser.parse_known_args()
+    print(f"Debug: args = {args}")
+    print(f"Debug: remaining = {remaining}")
+    
+    strategy_class = strategies[args.chunking_strategy]
+    
+    # Add strategy-specific arguments; build chunking strategy
+    strategy_parser = argparse.ArgumentParser()
+    strategy_class.add_arguments(strategy_parser)
+    strategy_args = strategy_parser.parse_args(remaining)
+    chunking_strategy = strategy_class.from_args(strategy_args)
+
+    chroma_db_name = generate_chroma_db_name(chunking_strategy, args.embedding_model)
+    
+    final_args = argparse.Namespace(
+        input=args.input,
+        output_dir=args.output_dir,
+        chroma_db_name=chroma_db_name,
+        chunking_strategy=chunking_strategy,
+        embedding_model=args.embedding_model,
+    )
+    
+    return final_args
+
+def load_document(input_path: str) -> str:
+    file_extension = os.path.splitext(input_path)[1].lower()
+    
+    if file_extension == '.txt':
+        with open(input_path, 'r', encoding='utf-8') as file:
+            return file.read()
+    elif file_extension in ['.pdf', '.docx']:
+        # TODO: Implement PDF and DOCX loading
+        raise NotImplementedError(f"Loading {file_extension} files is not yet implemented")
+    else:
+        raise ValueError(f"Unsupported file type: {file_extension}")
+
+def generate_embeddings(chunks: List[Chunk], model_name: str) -> List[List[float]]:
+    model = SentenceTransformer(model_name)
+    return model.encode([chunk.text for chunk in chunks]).tolist()
+
+def initialize_chroma(output_dir: str, chroma_db_name: str) -> chromadb.Client:
+    os.makedirs(output_dir, exist_ok=True)
+    return chromadb.PersistentClient(path="/".join([x.strip('/') for x in [output_dir, chroma_db_name]]))
+
+def add_to_chroma(client: chromadb.Client, collection_name: str, chunks: List[Chunk], embeddings: List[List[float]]) -> None:
+    collection = client.get_or_create_collection(collection_name)
+    for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+        # Convert metadata to appropriate types
+        metadata = {
+            **{k: str(v) if isinstance(v, list) else v for k, v in chunk.metadata.items()},
+            "start_index": chunk.start_index,
+            "end_index": chunk.end_index
+        }
+        collection.add(
+            documents=[chunk.text],
+            embeddings=[embedding],
+            metadatas=[metadata],
+            ids=[f"doc_{i}"]
+        )
+
+def process_document(args: argparse.Namespace) -> None:
+    # Load document
+    text = load_document(args.input)
+    
+    # Get chunking strategy
+    chunking_strategy = args.chunking_strategy
+    
+    # Chunk text
+    chunks = chunking_strategy.chunk(text)
+    
+    # Generate embeddings
+    embeddings = generate_embeddings(chunks, args.embedding_model)
+    
+    # Initialize ChromaDB
+    client = initialize_chroma(args.output_dir, args.chroma_db_name)
+    
+    # Add to ChromaDB
+    add_to_chroma(client, "documents", chunks, embeddings)
+    print_chroma_stats(client, "documents")
+    
+    print(f"Processed document using {chunking_strategy} and stored in {args.output_dir} with name {args.chroma_db_name}")
+
+
+def main():
+    args = parse_arguments()
+    process_document(args)
+
+if __name__ == "__main__":
+    main()

--- a/src/impact_explorer/cli/document_processor.py
+++ b/src/impact_explorer/cli/document_processor.py
@@ -1,38 +1,55 @@
 import argparse
 import os
-from typing import List, Tuple
-from chunking_strategies import ChunkingStrategy, strategies, Chunk
-from utils import print_chroma_stats
-import chromadb
 import re
+from typing import List
+
+import chromadb
+from chunking_strategies import Chunk, ChunkingStrategy, strategies
 from sentence_transformers import SentenceTransformer
+from utils import print_chroma_stats
+
 
 def sanitize_filename(name: str) -> str:
     """Sanitize the input string to be used as a filename."""
-    return re.sub(r'[^\w\-_\.]', '_', name)
+    return re.sub(r"[^\w\-_\.]", "_", name)
 
-def generate_chroma_db_name(chunking_strategy: ChunkingStrategy, embedding_model: str) -> str:
+
+def generate_chroma_db_name(
+    chunking_strategy: ChunkingStrategy, embedding_model: str
+) -> str:
     """Generate a unique ChromaDB name based on configuration."""
-    embedding_model_short = embedding_model.split('/')[-1]
+    embedding_model_short = embedding_model.split("/")[-1]
     db_name = f"{chunking_strategy}_{embedding_model_short}"
     return sanitize_filename(db_name)
+
 
 def parse_arguments() -> argparse.Namespace:
     print("Debug: Starting parse_arguments()")
 
     parser = argparse.ArgumentParser(description="Document Processor and Embedder")
     parser.add_argument("--input", required=True, help="Input file path or string")
-    parser.add_argument("--output-dir", default="./", help="Output directory for ChromaDB")
-    parser.add_argument("--chunking-strategy", required=True, choices=list(strategies.keys()), help="Chunking strategy to use")
-    parser.add_argument("--embedding-model", default="all-MiniLM-L6-v2", help="Name of the sentence-transformers model to use for embeddings")
-    
+    parser.add_argument(
+        "--output-dir", default="./", help="Output directory for ChromaDB"
+    )
+    parser.add_argument(
+        "--chunking-strategy",
+        required=True,
+        choices=list(strategies.keys()),
+        help="Chunking strategy to use",
+    )
+    parser.add_argument(
+        "--embedding-model",
+        default="all-MiniLM-L6-v2",
+        help="Name of the sentence-transformers model to use for embeddings",
+    )
+
     print("Debug: Parsing known arguments")
     args, remaining = parser.parse_known_args()
     print(f"Debug: args = {args}")
     print(f"Debug: remaining = {remaining}")
-    
+
     strategy_class = strategies[args.chunking_strategy]
-    
+
     # Add strategy-specific arguments; build chunking strategy
     strategy_parser = argparse.ArgumentParser()
     strategy_class.add_arguments(strategy_parser)
@@ -40,7 +57,7 @@ def parse_arguments() -> argparse.Namespace:
     chunking_strategy = strategy_class.from_args(strategy_args)
 
     chroma_db_name = generate_chroma_db_name(chunking_strategy, args.embedding_model)
-    
+
     final_args = argparse.Namespace(
         input=args.input,
         output_dir=args.output_dir,
@@ -48,71 +65,91 @@ def parse_arguments() -> argparse.Namespace:
         chunking_strategy=chunking_strategy,
         embedding_model=args.embedding_model,
     )
-    
+
     return final_args
+
 
 def load_document(input_path: str) -> str:
     file_extension = os.path.splitext(input_path)[1].lower()
-    
-    if file_extension == '.txt':
-        with open(input_path, 'r', encoding='utf-8') as file:
+
+    if file_extension == ".txt":
+        with open(input_path, "r", encoding="utf-8") as file:
             return file.read()
-    elif file_extension in ['.pdf', '.docx']:
+    elif file_extension in [".pdf", ".docx"]:
         # TODO: Implement PDF and DOCX loading
-        raise NotImplementedError(f"Loading {file_extension} files is not yet implemented")
+        raise NotImplementedError(
+            f"Loading {file_extension} files is not yet implemented"
+        )
     else:
         raise ValueError(f"Unsupported file type: {file_extension}")
+
 
 def generate_embeddings(chunks: List[Chunk], model_name: str) -> List[List[float]]:
     model = SentenceTransformer(model_name)
     return model.encode([chunk.text for chunk in chunks]).tolist()
 
+
 def initialize_chroma(output_dir: str, chroma_db_name: str) -> chromadb.Client:
     os.makedirs(output_dir, exist_ok=True)
-    return chromadb.PersistentClient(path="/".join([x.strip('/') for x in [output_dir, chroma_db_name]]))
+    return chromadb.PersistentClient(
+        path="/".join([x.strip("/") for x in [output_dir, chroma_db_name]])
+    )
 
-def add_to_chroma(client: chromadb.Client, collection_name: str, chunks: List[Chunk], embeddings: List[List[float]]) -> None:
+
+def add_to_chroma(
+    client: chromadb.Client,
+    collection_name: str,
+    chunks: List[Chunk],
+    embeddings: List[List[float]],
+) -> None:
     collection = client.get_or_create_collection(collection_name)
     for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
         # Convert metadata to appropriate types
         metadata = {
-            **{k: str(v) if isinstance(v, list) else v for k, v in chunk.metadata.items()},
+            **{
+                k: str(v) if isinstance(v, list) else v
+                for k, v in chunk.metadata.items()
+            },
             "start_index": chunk.start_index,
-            "end_index": chunk.end_index
+            "end_index": chunk.end_index,
         }
         collection.add(
             documents=[chunk.text],
             embeddings=[embedding],
             metadatas=[metadata],
-            ids=[f"doc_{i}"]
+            ids=[f"doc_{i}"],
         )
+
 
 def process_document(args: argparse.Namespace) -> None:
     # Load document
     text = load_document(args.input)
-    
+
     # Get chunking strategy
     chunking_strategy = args.chunking_strategy
-    
+
     # Chunk text
     chunks = chunking_strategy.chunk(text)
-    
+
     # Generate embeddings
     embeddings = generate_embeddings(chunks, args.embedding_model)
-    
+
     # Initialize ChromaDB
     client = initialize_chroma(args.output_dir, args.chroma_db_name)
-    
+
     # Add to ChromaDB
     add_to_chroma(client, "documents", chunks, embeddings)
     print_chroma_stats(client, "documents")
-    
-    print(f"Processed document using {chunking_strategy} and stored in {args.output_dir} with name {args.chroma_db_name}")
+
+    print(
+        f"Processed document using {chunking_strategy} and stored in {args.output_dir} with name {args.chroma_db_name}"
+    )
 
 
 def main():
     args = parse_arguments()
     process_document(args)
+
 
 if __name__ == "__main__":
     main()

--- a/src/impact_explorer/cli/document_processor.py
+++ b/src/impact_explorer/cli/document_processor.py
@@ -24,8 +24,6 @@ def generate_chroma_db_name(
 
 
 def parse_arguments() -> argparse.Namespace:
-    print("Debug: Starting parse_arguments()")
-
     parser = argparse.ArgumentParser(description="Document Processor and Embedder")
     parser.add_argument("--input", required=True, help="Input file path or string")
     parser.add_argument(
@@ -39,14 +37,11 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--embedding-model",
-        default="all-MiniLM-L6-v2",
+        default="distilbert-base-uncased",
         help="Name of the sentence-transformers model to use for embeddings",
     )
 
-    print("Debug: Parsing known arguments")
     args, remaining = parser.parse_known_args()
-    print(f"Debug: args = {args}")
-    print(f"Debug: remaining = {remaining}")
 
     strategy_class = strategies[args.chunking_strategy]
 
@@ -54,6 +49,7 @@ def parse_arguments() -> argparse.Namespace:
     strategy_parser = argparse.ArgumentParser()
     strategy_class.add_arguments(strategy_parser)
     strategy_args = strategy_parser.parse_args(remaining)
+    strategy_args.embedding_model = args.embedding_model
     chunking_strategy = strategy_class.from_args(strategy_args)
 
     chroma_db_name = generate_chroma_db_name(chunking_strategy, args.embedding_model)

--- a/src/impact_explorer/cli/utils.py
+++ b/src/impact_explorer/cli/utils.py
@@ -3,6 +3,48 @@ import subprocess
 import spacy
 
 
+def print_model_help():
+    """
+    Prints a high-level description of various SentenceTransformer models and their trade-offs.
+    """
+    help_text = """
+Available Pretrained Models and Trade-offs:
+-------------------------------------------
+1. all-MiniLM-L6-v2
+   - Size: 66M params | Max tokens: 256 | Speed: Very fast | Accuracy: Moderate
+   - Use Case: Large-scale, real-time search with moderate accuracy.
+
+2. all-MiniLM-L12-v2
+   - Size: 110M params | Max tokens: 256 | Speed: Fast | Accuracy: Better than L6
+   - Use Case: Fast general-purpose search with good accuracy.
+
+3. paraphrase-MiniLM-L6-v2
+   - Size: 66M params | Max tokens: 256 | Speed: Very fast | Accuracy: Moderate
+   - Use Case: Paraphrase detection, sentence similarity.
+
+4. paraphrase-MpNet-base-v2
+   - Size: 110M params | Max tokens: 256 | Speed: Fast | Accuracy: High
+   - Use Case: High-accuracy sentence similarity, semantic search.
+
+5. multi-qa-MiniLM-L6-cos-v1
+   - Size: 66M params | Max tokens: 256 | Speed: Very fast | Accuracy: QA-optimized
+   - Use Case: Question-answering, fast multi-lingual search.
+
+6. all-distilroberta-v1
+   - Size: 82M params | Max tokens: 512 | Speed: Moderate | Accuracy: High
+   - Use Case: Longer text, nuanced comparisons.
+
+7. msmarco-distilbert-base-v4
+   - Size: 66M params | Max tokens: 512 | Speed: Fast | Accuracy: Retrieval-optimized
+   - Use Case: Passage retrieval, document search.
+
+8. roberta-large-nli-stsb-mean-tokens
+   - Size: 355M params | Max tokens: 512 | Speed: Slow | Accuracy: Very high
+   - Use Case: High-accuracy semantic search, small-scale.
+"""
+    print(help_text)
+
+
 def print_chroma_stats(client: chromadb.Client, collection_name: str) -> None:
     collection = client.get_collection(collection_name)
 

--- a/src/impact_explorer/cli/utils.py
+++ b/src/impact_explorer/cli/utils.py
@@ -1,0 +1,47 @@
+import chromadb
+
+def print_chroma_stats(client: chromadb.Client, collection_name: str) -> None:
+    collection = client.get_collection(collection_name)
+    
+    print("\n" + "=" * 60)
+    print(" ChromaDB Collection Statistics ".center(60, "="))
+    print("=" * 60 + "\n")
+    
+    # Get the count of items
+    count = collection.count()
+    print(f"📊 Total documents: {count}")
+    
+    if count > 0:
+        # Peek at the first item
+        first_item = collection.peek(limit=1)
+        
+        # Embedding dimensionality
+        embedding_dim = len(first_item['embeddings'][0])
+        print(f"🧠 Embedding dimensions: {embedding_dim}")
+        
+        # Metadata keys
+        metadata_keys = set(first_item['metadatas'][0].keys())
+        print("\n📋 Metadata fields:")
+        for key in metadata_keys:
+            print(f"  • {key}")
+        
+        # Sample some items
+        sample_size = min(3, count)
+        sample = collection.get(ids=[f"doc_{i}" for i in range(sample_size)])
+        
+        print(f"\n🔍 Peek at {sample_size} documents:")
+        for i in range(sample_size):
+            print(f"\n  Document {i+1}:")
+            print(f"  {'ID:':<10} {sample['ids'][i]}")
+            print(f"  {'Preview:':<10} {sample['documents'][i][:100]}...")
+            print("  Metadata:")
+            for k, v in sample['metadatas'][i].items():
+                print(f"    {k:<15} {v}")
+        
+        # Some interesting stats
+        doc_lengths = [len(doc) for doc in sample['documents']]
+        avg_length = sum(doc_lengths) / len(doc_lengths)
+        print("\n📏 Document Statistics:")
+        print(f"  {'Average length:':<20} {avg_length:.2f} characters")
+        print(f"  {'Shortest document:':<20} {min(doc_lengths)} characters")
+        print(f"  {'Longest document:':<20} {max(doc_lengths)} characters")

--- a/src/impact_explorer/cli/utils.py
+++ b/src/impact_explorer/cli/utils.py
@@ -1,4 +1,6 @@
 import chromadb
+import subprocess
+import spacy
 
 
 def print_chroma_stats(client: chromadb.Client, collection_name: str) -> None:
@@ -46,3 +48,16 @@ def print_chroma_stats(client: chromadb.Client, collection_name: str) -> None:
         print(f"  {'Average length:':<20} {avg_length:.2f} characters")
         print(f"  {'Shortest document:':<20} {min(doc_lengths)} characters")
         print(f"  {'Longest document:':<20} {max(doc_lengths)} characters")
+
+
+def load_spacy_model():
+    """Load en_core_web_sm, installing as necessary"""
+    try:
+        nlp = spacy.load("en_core_web_sm")
+    except OSError:
+        print("Model 'en_core_web_sm' not found. Downloading now...")
+        subprocess.run(["python", "-m", "spacy", "download", "en_core_web_sm"])
+        nlp = spacy.load("en_core_web_sm")
+    # this means up to 2gb in mem. or like 1.5 moby dicks
+    nlp.max_length = 2000000
+    return nlp

--- a/src/impact_explorer/cli/utils.py
+++ b/src/impact_explorer/cli/utils.py
@@ -109,6 +109,8 @@ def load_spacy_model():
 
 def generate_doc_id(input_path: str) -> str:
     document_name = os.path.basename(input_path).replace(".", "-")
-    sanitized_name = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in document_name)
+    sanitized_name = "".join(
+        c if c.isalnum() or c in ("-", "_") else "_" for c in document_name
+    )
 
     return sanitized_name

--- a/src/impact_explorer/cli/utils.py
+++ b/src/impact_explorer/cli/utils.py
@@ -1,5 +1,6 @@
-import chromadb
 import subprocess
+
+import chromadb
 import spacy
 
 

--- a/src/impact_explorer/cli/utils.py
+++ b/src/impact_explorer/cli/utils.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 import chromadb
@@ -104,3 +105,10 @@ def load_spacy_model():
     # this means up to 2gb in mem. or like 1.5 moby dicks
     nlp.max_length = 2000000
     return nlp
+
+
+def generate_doc_id(input_path: str) -> str:
+    document_name = os.path.basename(input_path).replace(".", "-")
+    sanitized_name = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in document_name)
+
+    return sanitized_name

--- a/src/impact_explorer/cli/utils.py
+++ b/src/impact_explorer/cli/utils.py
@@ -1,45 +1,46 @@
 import chromadb
 
+
 def print_chroma_stats(client: chromadb.Client, collection_name: str) -> None:
     collection = client.get_collection(collection_name)
-    
+
     print("\n" + "=" * 60)
     print(" ChromaDB Collection Statistics ".center(60, "="))
     print("=" * 60 + "\n")
-    
+
     # Get the count of items
     count = collection.count()
     print(f"📊 Total documents: {count}")
-    
+
     if count > 0:
         # Peek at the first item
         first_item = collection.peek(limit=1)
-        
+
         # Embedding dimensionality
-        embedding_dim = len(first_item['embeddings'][0])
+        embedding_dim = len(first_item["embeddings"][0])
         print(f"🧠 Embedding dimensions: {embedding_dim}")
-        
+
         # Metadata keys
-        metadata_keys = set(first_item['metadatas'][0].keys())
+        metadata_keys = set(first_item["metadatas"][0].keys())
         print("\n📋 Metadata fields:")
         for key in metadata_keys:
             print(f"  • {key}")
-        
+
         # Sample some items
         sample_size = min(3, count)
         sample = collection.get(ids=[f"doc_{i}" for i in range(sample_size)])
-        
+
         print(f"\n🔍 Peek at {sample_size} documents:")
         for i in range(sample_size):
             print(f"\n  Document {i+1}:")
             print(f"  {'ID:':<10} {sample['ids'][i]}")
             print(f"  {'Preview:':<10} {sample['documents'][i][:100]}...")
             print("  Metadata:")
-            for k, v in sample['metadatas'][i].items():
+            for k, v in sample["metadatas"][i].items():
                 print(f"    {k:<15} {v}")
-        
+
         # Some interesting stats
-        doc_lengths = [len(doc) for doc in sample['documents']]
+        doc_lengths = [len(doc) for doc in sample["documents"]]
         avg_length = sum(doc_lengths) / len(doc_lengths)
         print("\n📏 Document Statistics:")
         print(f"  {'Average length:':<20} {avg_length:.2f} characters")

--- a/src/impact_explorer/utils.py
+++ b/src/impact_explorer/utils.py
@@ -22,25 +22,24 @@ When responding to queries:
    - Organizational structure
    - Current projects
 
-2. If the retrieved documents don't fully address the query or if clarification is needed, state this clearly and suggest how the user might refine their question.
+2. If the retrieved documents don't address the query or if clarification is needed, state this clearly and suggest how the user might refine their question.
 
 3. Synthesize information from the documents to provide a clear, concise answer. Use bullet points or numbered lists when appropriate.
 
 4. Always cite the specific documents you're drawing information from. Use inline citations (e.g., [Doc1], [Doc2]) to attribute information to its source.
 
-5. If the retrieved documents contain conflicting information, acknowledge this and present the different viewpoints, citing the sources for each.
+5. Provide context for your answer, explaining how the information relates to NASA operations or the user's potential tasks, based on details from the retrieved documents.
 
-6. Provide context for your answer, explaining how the information relates to NASA operations or the user's potential tasks, based on details from the retrieved documents.
+6. For complex topics, offer a brief overview followed by more detailed information from the documents, allowing the user to choose their desired depth of information.
 
-7. For complex topics, offer a brief overview followed by more detailed information from the documents, allowing the user to choose their desired depth of information.
+7. When discussing current projects (if covered in the retrieved documents), include relevant timelines, key personnel, and project goals.
 
-8. When discussing current projects (if covered in the retrieved documents), include relevant timelines, key personnel, and project goals.
+8. If the retrieved documents use technical jargon or NASA-specific acronyms, briefly explain these terms if they're crucial to understanding the answer.
 
-9. If the retrieved documents use technical jargon or NASA-specific acronyms, briefly explain these terms if they're crucial to understanding the answer.
-
-10. If the retrieved documents don't contain enough information to fully answer the query, clearly state this and suggest related topics the user might query instead.
+9. If the retrieved documents don't contain enough information to fully answer the query, clearly state this and suggest related topics the user might query instead.
 
 Remember, your goal is to accurately present and synthesize the information from the retrieved documents to assist NASA personnel in quickly accessing relevant information to support their work efficiently and effectively. Do not introduce information or assumptions beyond what is provided in the retrieved documents.
+At the same time, it is important for you to draw on your vast knowledge and do your best to relate relevant information when that is possible without specific documents.
 """
     return prompt.strip()
 


### PR DESCRIPTION
Example command to use a sliding window strategy with a window size of 100, an overlap of 20, and the all-MiniLM-L6-v2 embedding model provided by `sentence-transformers`. The output can be loaded for RAG queries on FastApi startup (not yet implemented)
```bash
python src/impact_explorer/cli/document_processor.py --input documents/mobydick.txt --output ./moby_db/ --chunking-strategy sliding-window --chunk_size 100 --overlap 20 --embedding-model all-MiniLM-L6-v2
```

Here's what's written:
<img width="456" alt="image" src="https://github.com/user-attachments/assets/70083cc3-867d-46e6-b382-be642264fd2e">

Output at the end of a run
```bash
============================================================
============== ChromaDB Collection Statistics ==============
============================================================

📊 Total documents: 15252
🧠 Embedding dimensions: 384

📋 Metadata fields:
  • length
  • end_index
  • start_index
  • tokens

🔍 Peek at 3 documents:

  Document 1:
  ID:        doc_0
  Preview:   MOBY DICK; OR THE WHALE

by Herman Melville




ETYMOLOGY.

(Supplied by a Late Consumptive Usher t...
  Metadata:
    end_index       100
    length          100
    start_index     0
    tokens          ['MOBY', 'DICK;', 'OR', 'THE', 'WHALE', 'by', 'Herman', 'Melville', 'ETYMOLOGY.', '(Supplied', 'by', 'a', 'Late', 'Consumptive', 'Usher', 't']

  Document 2:
  ID:        doc_1
  Preview:    Consumptive Usher to a Grammar School)

The pale Usher--threadbare in coat, heart, body, and brain;...
  Metadata:
    end_index       180
    length          100
    start_index     80
    tokens          ['Consumptive', 'Usher', 'to', 'a', 'Grammar', 'School)', 'The', 'pale', 'Usher--threadbare', 'in', 'coat,', 'heart,', 'body,', 'and', 'brain;']

  Document 3:
  ID:        doc_2
  Preview:   rt, body, and brain; I see him
now.  He was ever dusting his old lexicons and grammars, with a queer...
  Metadata:
    end_index       260
    length          100
    start_index     160
    tokens          ['rt,', 'body,', 'and', 'brain;', 'I', 'see', 'him', 'now.', 'He', 'was', 'ever', 'dusting', 'his', 'old', 'lexicons', 'and', 'grammars,', 'with', 'a', 'queer']

📏 Document Statistics:
  Average length:      100.00 characters
  Shortest document:   100 characters
  Longest document:    100 characters
Processed document using sliding-window_size-100_overlap-20 and stored in ./moby_db/ with name sliding-window_size-100_overlap-20_all-MiniLM-L6-v2
```